### PR TITLE
made bablpolyfill a dev dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,12 +35,12 @@
     "inquirer": "3.0.6",
     "minimist": "1.2.0",
     "node-fetch": "1.6.3",
-    "babel-polyfill": "6.23.0",
     "opn": "4.0.2"
   },
   "devDependencies": {
     "babel-cli": "6.24.1",
     "babel-core": "6.24.1",
+    "babel-polyfill": "6.23.0",
     "babel-preset-es2015": "6.24.1",
     "babel-preset-stage-0": "6.24.1",
     "babel-register": "6.14.0",


### PR DESCRIPTION
will cause package users to have babel-polyfill loaded in their production builds