### PR TITLE
Improves ansi escape sequence regex

### DIFF
--- a/src/lib/print.js
+++ b/src/lib/print.js
@@ -28,7 +28,8 @@ export function print(str, opts) {
   str = str || '';
   opts.align = opts.align || 'center';
   const terminalCols = process.platform === 'win32' ? 80 : parseInt(execSync(`tput cols`).toString());
-  const strLength = str.replace(/\u001b\[[0-9]{2}m/g,'').length;
+  const ansiEscapeSeq = /\u001b\[[0-9]{1,2}m/g
+  const strLength = str.replace(ansiEscapeSeq,'').length;
   const leftPaddingLength = (opts.align === 'center') ? Math.floor((terminalCols - strLength) / 2) : 2; 
   const leftPadding = padding(leftPaddingLength);
   if (opts.color) {

--- a/src/lib/print.js
+++ b/src/lib/print.js
@@ -28,8 +28,7 @@ export function print(str, opts) {
   str = str || '';
   opts.align = opts.align || 'center';
   const terminalCols = process.platform === 'win32' ? 80 : parseInt(execSync(`tput cols`).toString());
-  const ansiEscapeSeq = /\u001b\[[0-9]{1,2}m/g
-  const strLength = str.replace(ansiEscapeSeq,'').length;
+  const strLength = str.replace(/\u001b\[[0-9]{1,2}m/g,'').length;
   const leftPaddingLength = (opts.align === 'center') ? Math.floor((terminalCols - strLength) / 2) : 2; 
   const leftPadding = padding(leftPaddingLength);
   if (opts.color) {


### PR DESCRIPTION
It now matches also [sequences](https://github.com/shiena/ansicolor/blob/master/README.md) with one digit `\x1b[`_`m`


Escape sequence | Text attributes
-- | --
\x1b[0m | All attributes off(color at startup)
\x1b[1m | Bold on(enable foreground intensity)
\x1b[4m | Underline on
\x1b[5m | Blink on(enable background intensity)

